### PR TITLE
catch RejectedItemExceptions and log them instead of stopping the pipeline

### DIFF
--- a/src/Builder/Transformer.php
+++ b/src/Builder/Transformer.php
@@ -9,14 +9,18 @@ use Kiboko\Contract\Mapping\CompiledMapperInterface;
 use PhpParser\Builder;
 use PhpParser\Node;
 
-final readonly class Transformer implements StepBuilderInterface
+final class Transformer implements StepBuilderInterface
 {
-    public function __construct(private Builder|Node $mapper)
+    private ?Node\Expr $logger = null;
+
+    public function __construct(private readonly Builder|Node $mapper)
     {
     }
 
     public function withLogger(Node\Expr $logger): self
     {
+        $this->logger = $logger;
+
         return $this;
     }
 
@@ -54,6 +58,15 @@ final readonly class Transformer implements StepBuilderInterface
                                         ),
                                         flags: Node\Stmt\Class_::MODIFIER_PRIVATE
                                     ),
+                                    new Node\Param(
+                                        var: new Node\Expr\Variable(
+                                            name: 'logger'
+                                        ),
+                                        type: new Node\Name\FullyQualified(
+                                            name: \Psr\Log\LoggerInterface::class
+                                        ),
+                                        flags: Node\Stmt\Class_::MODIFIER_PUBLIC,
+                                    ),
                                 ],
                             ],
                         ),
@@ -64,45 +77,108 @@ final readonly class Transformer implements StepBuilderInterface
                                 'stmts' => [
                                     new Node\Stmt\Expression(
                                         new Node\Expr\Assign(
-                                            var: new Node\Expr\Variable('line'),
+                                            var: new Node\Expr\Variable('input'),
                                             expr: new Node\Expr\Yield_(null)
                                         ),
                                     ),
-                                    new Node\Stmt\Do_(
-                                        cond: new Node\Expr\Assign(
-                                            var: new Node\Expr\Variable('line'),
-                                            expr: new Node\Expr\Yield_(
-                                                new Node\Expr\New_(
-                                                    class: new Node\Name\FullyQualified(
-                                                        \Kiboko\Component\Bucket\AcceptanceResultBucket::class
-                                                    ),
-                                                    args: [
-                                                        new Node\Arg(
-                                                            new Node\Expr\Variable('line'),
-                                                        ),
-                                                    ],
-                                                )
+                                    new Node\Stmt\While_(
+                                        cond: new Node\Expr\BinaryOp\NotIdentical(
+                                            left: new Node\Expr\Variable('input'),
+                                            right: new Node\Expr\ConstFetch(
+                                                new Node\Name('null')
                                             )
                                         ),
                                         stmts: [
-                                            new Node\Stmt\Expression(
-                                                new Node\Expr\Assign(
-                                                    var: new Node\Expr\Variable('line'),
-                                                    expr: new Node\Expr\FuncCall(
-                                                        name: new Node\Expr\PropertyFetch(
-                                                            var: new Node\Expr\Variable('this'),
-                                                            name: new Node\Identifier('mapper'),
+                                            new Node\Stmt\TryCatch(
+                                                stmts: [
+                                                    new Node\Stmt\Expression(
+                                                        new Node\Expr\Assign(
+                                                            var: new Node\Expr\Variable('line'),
+                                                            expr: new Node\Expr\FuncCall(
+                                                                name: new Node\Expr\PropertyFetch(
+                                                                    var: new Node\Expr\Variable('this'),
+                                                                    name: new Node\Identifier('mapper'),
+                                                                ),
+                                                                args: [
+                                                                    new Node\Arg(
+                                                                        value: new Node\Expr\Variable('input')
+                                                                    ),
+                                                                    new Node\Arg(
+                                                                        value: new Node\Expr\Variable('input')
+                                                                    ),
+                                                                ]
+                                                            ),
                                                         ),
-                                                        args: [
-                                                            new Node\Arg(
-                                                                value: new Node\Expr\Variable('line')
+                                                    ),
+                                                ],
+                                                catches: [
+                                                    new Node\Stmt\Catch_(
+                                                        types: [
+                                                            new Node\Name\FullyQualified('Kiboko\\Contract\\Pipeline\\RejectedItemException'),
+                                                        ],
+                                                        var: new Node\Expr\Variable('exception'),
+                                                        stmts: [
+                                                            new Node\Stmt\Expression(
+                                                                new Node\Expr\MethodCall(
+                                                                    var: new Node\Expr\PropertyFetch(
+                                                                        var: new Node\Expr\Variable('this'),
+                                                                        name: new Node\Identifier('logger'),
+                                                                    ),
+                                                                    name: new Node\Name('error'),
+                                                                    args: [
+                                                                        new Node\Arg(
+                                                                            new Node\Expr\MethodCall(
+                                                                                var: new Node\Expr\Variable('exception'),
+                                                                                name: new Node\Identifier('getMessage')
+                                                                            )
+                                                                        ),
+                                                                        new Node\Expr\Array_([
+                                                                            new Node\Expr\ArrayItem(
+                                                                                value: new Node\Expr\Variable('input'),
+                                                                                key: new Node\Scalar\String_('input')
+                                                                            ),
+                                                                        ]),
+                                                                    ]
+                                                                )
                                                             ),
-                                                            new Node\Arg(
-                                                                value: new Node\Expr\Variable('line')
+                                                            new Node\Stmt\Expression(
+                                                                new Node\Expr\Assign(
+                                                                    var: new Node\Expr\Variable('input'),
+                                                                    expr: new Node\Expr\Yield_(
+                                                                        new Node\Expr\New_(
+                                                                            class: new Node\Name\FullyQualified(
+                                                                                \Kiboko\Component\Bucket\RejectionResultBucket::class
+                                                                            ),
+                                                                            args: [
+                                                                                new Node\Arg(
+                                                                                    new Node\Expr\Variable('input'),
+                                                                                ),
+                                                                            ],
+                                                                        )
+                                                                    )
+                                                                ),
                                                             ),
+                                                            new Node\Stmt\Continue_(),
                                                         ]
                                                     ),
-                                                ),
+                                                ]
+                                            ),
+                                            new Node\Stmt\Expression(
+                                                new Node\Expr\Assign(
+                                                    var: new Node\Expr\Variable('input'),
+                                                    expr: new Node\Expr\Yield_(
+                                                        new Node\Expr\New_(
+                                                            class: new Node\Name\FullyQualified(
+                                                                \Kiboko\Component\Bucket\AcceptanceResultBucket::class
+                                                            ),
+                                                            args: [
+                                                                new Node\Arg(
+                                                                    new Node\Expr\Variable('line'),
+                                                                ),
+                                                            ],
+                                                        )
+                                                    )
+                                                )
                                             ),
                                         ],
                                     ),
@@ -114,7 +190,7 @@ final readonly class Transformer implements StepBuilderInterface
                                                 ),
                                                 args: [
                                                     new Node\Arg(
-                                                        new Node\Expr\Variable('line'),
+                                                        new Node\Expr\Variable('input'),
                                                     ),
                                                 ],
                                             ),
@@ -130,6 +206,9 @@ final readonly class Transformer implements StepBuilderInterface
             args: [
                 new Node\Arg(
                     $this->mapper instanceof Builder ? $this->mapper->getNode() : $this->mapper,
+                ),
+                new Node\Arg(
+                    $this->logger ?? new Node\Expr\New_(new Node\Name\FullyQualified(\Psr\Log\NullLogger::class))
                 ),
             ],
         );

--- a/src/Builder/Transformer.php
+++ b/src/Builder/Transformer.php
@@ -114,7 +114,7 @@ final class Transformer implements StepBuilderInterface
                                                 catches: [
                                                     new Node\Stmt\Catch_(
                                                         types: [
-                                                            new Node\Name\FullyQualified('Kiboko\\Contract\\Pipeline\\RejectedItemException'),
+                                                            new Node\Name\FullyQualified(\Kiboko\Contract\Pipeline\RejectedItemException::class),
                                                         ],
                                                         var: new Node\Expr\Variable('exception'),
                                                         stmts: [


### PR DESCRIPTION
avant:
```
public function transform() : \Generator
{
    $line = yield;
    do {
        $line = ($this->mapper)($line, $line);
    } while ($line = (yield new \Kiboko\Component\Bucket\AcceptanceResultBucket($line)));
    (yield new \Kiboko\Component\Bucket\AcceptanceResultBucket($line));
}
```
après:
```
public function transform() : \Generator
{
    $input = yield;
    while ($input !== null) {
        try {
            $line = ($this->mapper)($input, $input);
        } catch (\Kiboko\Contract\Pipeline\RejectedItemException $exception) {
            $this->logger->error($exception->getMessage(), array('input' => $input));
            $input = (yield new \Kiboko\Component\Bucket\RejectionResultBucket($input));
            continue;
        }
        $input = (yield new \Kiboko\Component\Bucket\AcceptanceResultBucket($line));
    }
    (yield new \Kiboko\Component\Bucket\AcceptanceResultBucket($input));
}
```