### PR TITLE
Udated dependencies version into the Configurator\Pipeline attribute

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -14,7 +14,9 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 #[Configurator\Pipeline(
     name: 'fastmap',
     dependencies: [
-        'php-etl/mapping-contracts:0.4.*'
+        'php-etl/pipeline-contracts:0.5.*',
+        'php-etl/bucket-contracts:0.3.*',
+        'php-etl/bucket:*',
     ],
     steps: [
         new Configurator\Pipeline\StepTransformer(null),

--- a/src/Service.php
+++ b/src/Service.php
@@ -14,8 +14,8 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 #[Configurator\Pipeline(
     name: 'fastmap',
     dependencies: [
-        'php-etl/pipeline-contracts:0.5.*',
-        'php-etl/bucket-contracts:0.3.*',
+        'php-etl/pipeline-contracts:>=0.5.1 <0.6',
+        'php-etl/bucket-contracts:>=0.3.0 <0.4',
         'php-etl/bucket:*',
     ],
     steps: [


### PR DESCRIPTION
Mise à jour des versions des contrats utilisés

:warning: Par contre le fait d'ajouter des `"` autour des versions résout un bug pour le build des images via Docker 

Sans les `"`, on a ça  et plus tard un crash
![image](https://github.com/php-etl/json-plugin/assets/47692802/cbaf0bf7-0a52-47da-be2f-2eef5e5bf922)

Cependant, le fait d'ajouter ces `"` casse le fonctionnement pour un build sur le système...

Il faut trouver une solution pour ajouter ces `"` uniquement dans les commandes RUN du Dockerfile...